### PR TITLE
[ALBE-0009] default/iac-gitops-platform: update module call to v3

### DIFF
--- a/default/iac-gitops-platform/terragrunt.hcl
+++ b/default/iac-gitops-platform/terragrunt.hcl
@@ -3,7 +3,7 @@ include "root" {
 }
 
 terraform {
-  source = "${local.module_source_url}?ref=v1"
+  source = "${local.module_source_url}?ref=v3"
 }
 
 locals {


### PR DESCRIPTION
* [ ] Resource destruction expected

## Description

default/iac-gitops-platform: update module call to v3.
